### PR TITLE
68 - performance

### DIFF
--- a/src/leander-core-expressions-inference.adb
+++ b/src/leander-core-expressions-inference.adb
@@ -141,7 +141,11 @@ package body Leander.Core.Expressions.Inference is
                   S1 : constant Core.Substitutions.Instance'Class :=
                          TI (E.Left);
                begin
-                  Context.Save_Type_Env (Context.Type_Env.Apply (S1));
+                  if S1.Is_Empty then
+                     Context.Save_Type_Env;
+                  else
+                     Context.Save_Type_Env (Context.Type_Env.Apply (S1));
+                  end if;
 
                   declare
                      S2 : constant Core.Substitutions.Instance'Class :=

--- a/src/leander-core-substitutions.ads
+++ b/src/leander-core-substitutions.ads
@@ -10,6 +10,8 @@ package Leander.Core.Substitutions is
 
    function Empty return Instance;
 
+   function Is_Empty (This : Instance) return Boolean;
+
    function Compose
      (Left  : Instance;
       Right : Instance)
@@ -61,6 +63,9 @@ private
       end record;
 
    overriding function Show (This : Instance) return String;
+
+   function Is_Empty (This : Instance) return Boolean
+   is (This.List.Is_Empty);
 
    function Singleton
      (Name  : Leander.Names.Leander_Name;


### PR DESCRIPTION
When inferring an application, the left substitution is often empty.  In this case, don't apply it.